### PR TITLE
Update dante config to work with Mixed IPv6 AND IPv4 by default

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -120,11 +120,11 @@ user.privileged: root
 user.notprivileged: nobody
 user.libwrap: nobody
 client pass {
-        from: 0.0.0.0/0 port 1-65535 to: 0.0.0.0/0
+        from: 0/0 port 1-65535 to: 0/0
         log: connect disconnect error
 }
 socks pass {
-        from: 0.0.0.0/0 to: 0.0.0.0/0
+        from: 0/0 to: 0/0
         protocol: tcp udp
 }
 EOT


### PR DESCRIPTION
Update dante conf to add a rule that accepts any address, regardless of address family, with the following special Dante-specific address syntax (0/0):

#accept connections from any client
client pass {
        from: 0/0 to: 0/0
}

The rule above will match both IPv4 and IPv6 clients, connecting to either Dante's internal IPv4 address (if any) or Dante's internal IPv6 address (if any).

Refer - https://www.inet.no/dante/doc/latest/config/ipv6.html